### PR TITLE
Update php-examples.md

### DIFF
--- a/sections/php-examples.md
+++ b/sections/php-examples.md
@@ -10,7 +10,7 @@ Adding new task
 $ch = curl_init();
 curl_setopt($ch,CURLOPT_URL,'https://www.timecamp.com/third_party/api/tasks/api_token/a36ca9cba82');
 curl_setopt($ch,CURLOPT_POST, 1);
-curl_setopt($ch,CURLOPT_POSTFIELDS, array('name' => 'Task API', 'keywords' => 'keyword 1, keyword 2'));
+curl_setopt($ch,CURLOPT_POSTFIELDS, array('name' => 'Task API', 'tags' => 'tags 1, tags 2'));
 curl_setopt($ch, CURLOPT_RETURNTRANSFER, 1);
 $result = curl_exec($ch);
 curl_close($ch);


### PR DESCRIPTION
Database has no "keywords" column defined.
Duplicated pull request, because Github.